### PR TITLE
feat: Add `focusRevealProps.disableTargetInteraction` to disable target component interactions

### DIFF
--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.story.tsx
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.story.tsx
@@ -15,11 +15,13 @@ export default {
   args: {
     withReveal: true,
     withOverlay: true,
+    disableInteraction: false,
     focusedMode: 'none',
   },
   argTypes: {
     withReveal: { control: { type: 'boolean' } },
     withOverlay: { control: { type: 'boolean' } },
+    disableInteraction: { control: { type: 'boolean' } },
     focusedMode: {
       control: {
         type: 'select',

--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.story.tsx
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.story.tsx
@@ -15,13 +15,13 @@ export default {
   args: {
     withReveal: true,
     withOverlay: true,
-    disableInteraction: false,
+    disableTargetInteraction: false,
     focusedMode: 'none',
   },
   argTypes: {
     withReveal: { control: { type: 'boolean' } },
     withOverlay: { control: { type: 'boolean' } },
-    disableInteraction: { control: { type: 'boolean' } },
+    disableTargetInteraction: { control: { type: 'boolean' } },
     focusedMode: {
       control: {
         type: 'select',

--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
@@ -91,7 +91,7 @@ export interface OnboardingTourFocusRevealBaseProps {
   popoverProps?: Omit<PopoverProps, 'withinPortal'>;
 
   /** Disable interactions on the target component */
-  disableInteraction?: boolean;
+  disableTargetInteraction?: boolean;
 
   /** Called when OnboardingTourFocusReveal focused state changes */
   onChange?: (focused: boolean) => void;
@@ -171,7 +171,7 @@ export function OnboardingTourFocusReveal(_props: OnboardingTourFocusRevealProps
   const {
     focused,
     defaultFocused,
-    disableInteraction,
+    disableTargetInteraction,
     withOverlay,
     overlayProps,
     withReveal,
@@ -292,7 +292,7 @@ export function OnboardingTourFocusReveal(_props: OnboardingTourFocusRevealProps
         position: 'relative',
         ...child.props.style,
         zIndex: realFocused ? 201 : 0,
-        pointerEvents: disableInteraction ? 'none' : undefined
+        pointerEvents: disableTargetInteraction ? 'none' : undefined,
       },
     };
 

--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
@@ -90,6 +90,9 @@ export interface OnboardingTourFocusRevealBaseProps {
   /** Props passed down to the `Popover` component */
   popoverProps?: Omit<PopoverProps, 'withinPortal'>;
 
+  /** Disable interactions on the target component */
+  disableInteraction?: boolean;
+
   /** Called when OnboardingTourFocusReveal focused state changes */
   onChange?: (focused: boolean) => void;
 
@@ -168,6 +171,7 @@ export function OnboardingTourFocusReveal(_props: OnboardingTourFocusRevealProps
   const {
     focused,
     defaultFocused,
+    disableInteraction,
     withOverlay,
     overlayProps,
     withReveal,
@@ -288,6 +292,7 @@ export function OnboardingTourFocusReveal(_props: OnboardingTourFocusRevealProps
         position: 'relative',
         ...child.props.style,
         zIndex: realFocused ? 201 : 0,
+        pointerEvents: disableInteraction ? 'none' : undefined
       },
     };
 


### PR DESCRIPTION
Close https://github.com/gfazioli/mantine-onboarding-tour/issues/16