### PR TITLE
fix: onboarding tour popover width cap + positioning defaults (#44, #41)

### DIFF
--- a/docs/demos/FocusReveal.demo.popoverWidth.tsx
+++ b/docs/demos/FocusReveal.demo.popoverWidth.tsx
@@ -1,0 +1,98 @@
+import { OnboardingTour } from '@gfazioli/mantine-onboarding-tour';
+import { Button, Center, Divider, Stack, Text, Title } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { MantineDemo } from '@mantinex/demo';
+import { Testimonials } from './Testimonials';
+
+function Wrapper() {
+  const [focused, { close, open }] = useDisclosure(false);
+
+  return (
+    <Stack justify="center" align="center">
+      <Title order={4}>Popover width example</Title>
+
+      <Center>
+        <Button onClick={open}>Reveal the Bottom Card</Button>
+      </Center>
+
+      <Divider my={200} label="Divider" />
+
+      <Center>
+        <OnboardingTour.FocusReveal
+          focused={focused}
+          onBlur={close}
+          popoverContent={
+            <Stack gap="xs">
+              <Title order={5}>A step with a lot of content</Title>
+              <Text size="sm">
+                Without a width ceiling the dropdown grows to fit its content on a single line
+                (width: max-content), so wide or non-wrapping content overflows the viewport. The
+                default max-width of 400px keeps the popover readable and on-screen.
+              </Text>
+            </Stack>
+          }
+          popoverProps={{
+            position: 'top',
+            // Default max-width is 400px. Uncomment to change it (use 'none' to remove the cap):
+            // styles: { dropdown: { maxWidth: 560 } },
+          }}
+        >
+          <Testimonials testimonial={0} />
+        </OnboardingTour.FocusReveal>
+      </Center>
+    </Stack>
+  );
+}
+
+const code = `
+import { OnboardingTour } from '@gfazioli/mantine-onboarding-tour';
+import { Button, Center, Divider, Stack, Text, Title } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+
+function Demo() {
+  const [focused, { close, open }] = useDisclosure(false);
+
+  return (
+    <Stack justify="center" align="center">
+      <Title order={4}>Popover width example</Title>
+
+      <Center>
+        <Button onClick={open}>Reveal the Bottom Card</Button>
+      </Center>
+
+      <Divider my={200} label="Divider" />
+
+      <Center>
+        <OnboardingTour.FocusReveal
+          focused={focused}
+          onBlur={close}
+          popoverContent={
+            <Stack gap="xs">
+              <Title order={5}>A step with a lot of content</Title>
+              <Text size="sm">
+                Without a width ceiling the dropdown grows to fit its content on a single line
+                (width: max-content), so wide or non-wrapping content overflows the viewport. The
+                default max-width of 400px keeps the popover readable and on-screen.
+              </Text>
+            </Stack>
+          }
+          popoverProps={{
+            position: 'top',
+            // Default max-width is 400px. Uncomment to change it (use 'none' to remove the cap):
+            // styles: { dropdown: { maxWidth: 560 } },
+          }}
+        >
+          <Testimonials testimonial={0} />
+        </OnboardingTour.FocusReveal>
+      </Center>
+    </Stack>
+  );
+}
+`;
+
+export const focusRevealPopoverWidth: MantineDemo = {
+  type: 'code',
+  component: Wrapper,
+  code,
+  defaultExpanded: false,
+};

--- a/docs/demos/index.ts
+++ b/docs/demos/index.ts
@@ -9,6 +9,7 @@ export { focusRevealOverlay } from './FocusReveal.demo.overlay';
 export { focusRevealPaper } from './FocusReveal.demo.paper';
 export { focusRevealPopover } from './FocusReveal.demo.popover';
 export { focusRevealPopoverProps } from './FocusReveal.demo.popoverProps';
+export { focusRevealPopoverWidth } from './FocusReveal.demo.popoverWidth';
 export { focusRevealReveal } from './FocusReveal.demo.reveal';
 export { focusRevealScrollContainer } from './FocusReveal.demo.scrollContainer';
 export { focusRevealUncontrolled } from './FocusReveal.demo.uncontrolled';

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -585,6 +585,10 @@ The popover dropdown has a **default `max-width` of `400px`**, so wide or non-wr
 
 `styles.dropdown` is applied after the internal `width`, so `max-width` wins over the default `width: 'max-content'`. Both `popoverProps.width` and `popoverProps.styles.dropdown.maxWidth` accept per-tour and per-step values via `focusRevealProps`.
 
+Reveal the card below: the popover holds a long paragraph but stays capped at `400px` and wraps instead of overflowing.
+
+<Demo data={demos.focusRevealPopoverWidth} />
+
 ## Example: Cycle
 
 Here are some examples of how to use the `OnboardingTour.FocusReveal` component in different scenarios.

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -613,8 +613,8 @@ popoverProps: {
   arrowSize: 16,
   offset: -4,
   middlewares: { shift: { padding: 20 }, flip: true },
-  styles: { dropdown: { maxWidth: 400 } },
 }
+// The dropdown is additionally capped at `max-width: 400px` by default (see "Popover width").
 ```
 
 ### Responsive Demo

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -563,6 +563,28 @@ You can use the `popoverProps` prop (are the same as the Mantine `Popover` compo
 
 <Demo data={demos.focusRevealPopoverProps} />
 
+### Popover width
+
+The popover dropdown has a **default `max-width` of `400px`**, so wide or non-wrapping content (images, code blocks, fixed-width layouts) stays inside the viewport instead of overflowing. Note that `maw` set on `<OnboardingTour>` (or a step) sizes the **inner content box**, not the dropdown itself — to size the dropdown, use `popoverProps`:
+
+```tsx
+<OnboardingTour
+  focusRevealProps={{
+    popoverProps: {
+      // Fixed width…
+      width: 320,
+      // …or change the ceiling (overrides the 400px default; use 'none' to remove it):
+      styles: { dropdown: { maxWidth: 560 } },
+    },
+  }}
+  tour={steps}
+>
+  {/* ... */}
+</OnboardingTour>
+```
+
+`styles.dropdown` is applied after the internal `width`, so `max-width` wins over the default `width: 'max-content'`. Both `popoverProps.width` and `popoverProps.styles.dropdown.maxWidth` accept per-tour and per-step values via `focusRevealProps`.
+
 ## Example: Cycle
 
 Here are some examples of how to use the `OnboardingTour.FocusReveal` component in different scenarios.
@@ -587,6 +609,7 @@ popoverProps: {
   arrowSize: 16,
   offset: -4,
   middlewares: { shift: { padding: 20 }, flip: true },
+  styles: { dropdown: { maxWidth: 400 } },
 }
 ```
 

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -571,9 +571,9 @@ The popover dropdown has a **default `max-width` of `400px`**, so wide or non-wr
 <OnboardingTour
   focusRevealProps={{
     popoverProps: {
-      // Fixed width…
+      // Size the dropdown *up to* the 400px cap:
       width: 320,
-      // …or change the ceiling (overrides the 400px default; use 'none' to remove it):
+      // Go wider than 400px — raise or remove the cap (`width` alone cannot exceed max-width; use 'none' to remove it):
       styles: { dropdown: { maxWidth: 560 } },
     },
   }}
@@ -583,7 +583,7 @@ The popover dropdown has a **default `max-width` of `400px`**, so wide or non-wr
 </OnboardingTour>
 ```
 
-`styles.dropdown` is applied after the internal `width`, so `max-width` wins over the default `width: 'max-content'`. Both `popoverProps.width` and `popoverProps.styles.dropdown.maxWidth` accept per-tour and per-step values via `focusRevealProps`.
+`styles.dropdown.maxWidth` is applied after the internal `width`, so it wins over the default `width: 'max-content'`. Because the cap is a `max-width`, `popoverProps.width` can only make the dropdown **narrower** than `400px` — to make it **wider**, raise (or remove) the cap via `styles.dropdown.maxWidth`. Both accept per-tour and per-step values via `focusRevealProps`.
 
 Reveal the card below: the popover holds a long paragraph but stays capped at `400px` and wraps instead of overflowing.
 

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -613,6 +613,7 @@ popoverProps: {
   arrowSize: 16,
   offset: -4,
   middlewares: { shift: { padding: 20 }, flip: true },
+  preventPositionChangeWhenVisible: false,
 }
 // The dropdown is additionally capped at `max-width: 400px` by default (see "Popover width").
 ```
@@ -685,6 +686,17 @@ const steps: OnboardingTourStep[] = [
 ## Scroll Behavior
 
 When a step activates, the target element is automatically scrolled into view and **centered** in the viewport. The Floating UI `shift` and `flip` middlewares then ensure the popover stays fully visible regardless of the resolved position.
+
+Because the tour keeps moving the target around, the popover keeps re-positioning **while a step is visible** by default — the library sets `preventPositionChangeWhenVisible: false` in its default `popoverProps`. Mantine 9.3 changed the `Popover` default for this prop to `true` (the popover picks its side on open and no longer flips or shifts while it stays visible); the tour opts out so its scroll-and-reposition behavior is identical across Mantine versions. To pin the popover's side on open instead, set it back to `true`:
+
+```tsx
+<OnboardingTour
+  focusRevealProps={{ popoverProps: { preventPositionChangeWhenVisible: true } }}
+  tour={steps}
+>
+  {/* ... */}
+</OnboardingTour>
+```
 
 ## Cutout Highlight
 

--- a/jsdom.mocks.cjs
+++ b/jsdom.mocks.cjs
@@ -24,3 +24,25 @@ class ResizeObserver {
 }
 
 window.ResizeObserver = ResizeObserver;
+
+// Report observed elements as visible so viewport-gated UI (e.g. the tour popover, which only
+// opens once its target is in the viewport) can be exercised in jsdom tests.
+class IntersectionObserver {
+  constructor(callback) {
+    this.callback = callback;
+  }
+  observe(element) {
+    this.callback([{ isIntersecting: true, intersectionRatio: 1, target: element }], this);
+  }
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+window.IntersectionObserver = IntersectionObserver;
+global.IntersectionObserver = IntersectionObserver;
+
+// jsdom does not implement scrollIntoView; the tour calls it when a step is focused.
+window.HTMLElement.prototype.scrollIntoView = () => {};

--- a/package/src/OnboardingTour.test.tsx
+++ b/package/src/OnboardingTour.test.tsx
@@ -8,7 +8,10 @@ import {
   useOnboardingTour,
 } from './hooks/use-onboarding-tour/use-onboarding-tour';
 import { OnboardingTour } from './OnboardingTour';
-import { OnboardingTourFocusReveal } from './OnboardingTourFocusReveal/OnboardingTourFocusReveal';
+import {
+  defaultProps as focusRevealDefaultProps,
+  OnboardingTourFocusReveal,
+} from './OnboardingTourFocusReveal/OnboardingTourFocusReveal';
 
 const onboardingSteps: OnboardingTourStep[] = [
   {
@@ -450,6 +453,20 @@ describe('Popover dropdown sizing (#44)', () => {
     expect(dropdown).toHaveStyle({ backgroundColor: 'rgb(1, 2, 3)' });
     // The default cap class is still applied alongside the consumer's styles override.
     expect(dropdown.classList.contains('dropdown')).toBe(true);
+  });
+});
+
+// ─── Popover positioning defaults (issue #41) ───────────────────────────────
+
+describe('Popover positioning defaults (#41)', () => {
+  it('opts out of preventPositionChangeWhenVisible so the popover keeps re-positioning', () => {
+    // Mantine 9.3 flipped Popover's `preventPositionChangeWhenVisible` default to `true` (pins the
+    // side on open). The tour scrolls targets around, so it must keep flipping/shifting while a step
+    // is visible — lock the opt-out here so it can't silently regress across Mantine versions.
+    expect(
+      (focusRevealDefaultProps.popoverProps as { preventPositionChangeWhenVisible?: boolean })
+        ?.preventPositionChangeWhenVisible
+    ).toBe(false);
   });
 });
 

--- a/package/src/OnboardingTour.test.tsx
+++ b/package/src/OnboardingTour.test.tsx
@@ -8,7 +8,10 @@ import {
   useOnboardingTour,
 } from './hooks/use-onboarding-tour/use-onboarding-tour';
 import { OnboardingTour } from './OnboardingTour';
-import { OnboardingTourFocusReveal } from './OnboardingTourFocusReveal/OnboardingTourFocusReveal';
+import {
+  defaultProps as focusRevealDefaultProps,
+  OnboardingTourFocusReveal,
+} from './OnboardingTourFocusReveal/OnboardingTourFocusReveal';
 
 const onboardingSteps: OnboardingTourStep[] = [
   {
@@ -396,6 +399,44 @@ describe('FocusReveal', () => {
       </OnboardingTourFocusReveal>
     );
     expect(container.querySelector('[data-onboarding-tour-focus-reveal-overlay]')).toBeNull();
+  });
+});
+
+// ─── Popover dropdown sizing (issue #44) ────────────────────────────────────
+
+describe('Popover dropdown sizing (#44)', () => {
+  it('sets a default max-width on the popover dropdown', () => {
+    // Without a width ceiling the dropdown is `width: max-content` / `max-width: none`, so wide or
+    // non-wrapping content overflows the viewport and — combined with the tour's `overflow-x: hidden`
+    // — makes `position` look broken. Locking the default here prevents a regression.
+    const styles = (
+      focusRevealDefaultProps.popoverProps as { styles?: { dropdown?: React.CSSProperties } }
+    )?.styles;
+    expect(styles?.dropdown?.maxWidth).toBe(400);
+  });
+
+  it('renders with both tour-level and step-level focusRevealProps.popoverProps (deep-merge path)', () => {
+    // A step that sets its own popoverProps must not drop the tour-level popoverProps; this exercises
+    // the deep-merge in wrapChildren without throwing.
+    const steps: OnboardingTourStep[] = [
+      {
+        id: 'welcome',
+        title: 'Welcome',
+        content: 'Content',
+        focusRevealProps: { popoverProps: { position: 'top' } },
+      },
+    ];
+    const { container } = render(
+      <OnboardingTour
+        tour={steps}
+        started
+        focusRevealProps={{ popoverProps: { styles: { dropdown: { maxWidth: 500 } } } }}
+      >
+        <Button data-onboarding-tour-id="welcome">Target</Button>
+      </OnboardingTour>
+    );
+    expect(container).toBeTruthy();
+    expect(screen.getByText('Target')).toBeInTheDocument();
   });
 });
 

--- a/package/src/OnboardingTour.test.tsx
+++ b/package/src/OnboardingTour.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@mantine-tests/core';
 import { Button, MantineProvider, Title } from '@mantine/core';
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { buildCutoutPath } from './hooks/use-cutout-rect/use-cutout-rect';
 import {
@@ -8,10 +8,7 @@ import {
   useOnboardingTour,
 } from './hooks/use-onboarding-tour/use-onboarding-tour';
 import { OnboardingTour } from './OnboardingTour';
-import {
-  defaultProps as focusRevealDefaultProps,
-  OnboardingTourFocusReveal,
-} from './OnboardingTourFocusReveal/OnboardingTourFocusReveal';
+import { OnboardingTourFocusReveal } from './OnboardingTourFocusReveal/OnboardingTourFocusReveal';
 
 const onboardingSteps: OnboardingTourStep[] = [
   {
@@ -405,19 +402,31 @@ describe('FocusReveal', () => {
 // ─── Popover dropdown sizing (issue #44) ────────────────────────────────────
 
 describe('Popover dropdown sizing (#44)', () => {
-  it('sets a default max-width on the popover dropdown', () => {
-    // Without a width ceiling the dropdown is `width: max-content` / `max-width: none`, so wide or
-    // non-wrapping content overflows the viewport and — combined with the tour's `overflow-x: hidden`
-    // — makes `position` look broken. Locking the default here prevents a regression.
-    const styles = (
-      focusRevealDefaultProps.popoverProps as { styles?: { dropdown?: React.CSSProperties } }
-    )?.styles;
-    expect(styles?.dropdown?.maxWidth).toBe(400);
+  // The popover only opens once its target is in the viewport; the IntersectionObserver mock in
+  // jsdom.mocks.cjs reports elements as visible so the dropdown mounts.
+  const findDropdown = () =>
+    waitFor(() => {
+      const el = document.querySelector('.mantine-Popover-dropdown');
+      expect(el).toBeInTheDocument();
+      return el as HTMLElement;
+    });
+
+  it('applies the default width-cap class to the tour popover dropdown', async () => {
+    // The default `max-width: 400px` ships as a CSS class (not inline `styles`) so it survives
+    // consumer `styles.dropdown` overrides of other properties. CSS modules are mocked with
+    // identity-obj-proxy, so the class token equals its key ('dropdown').
+    render(
+      <OnboardingTour tour={onboardingSteps} started>
+        <Button data-onboarding-tour-id="welcome">Target</Button>
+      </OnboardingTour>
+    );
+    const dropdown = await findDropdown();
+    expect(dropdown.classList.contains('dropdown')).toBe(true);
   });
 
-  it('renders with both tour-level and step-level focusRevealProps.popoverProps (deep-merge path)', () => {
-    // A step that sets its own popoverProps must not drop the tour-level popoverProps; this exercises
-    // the deep-merge in wrapChildren without throwing.
+  it('deep-merges tour-level and step-level popoverProps (step does not drop tour settings)', async () => {
+    // The step overrides only `position`; the tour-level `styles.dropdown` must survive the merge
+    // (a shallow spread would replace the whole popoverProps and lose it).
     const steps: OnboardingTourStep[] = [
       {
         id: 'welcome',
@@ -426,17 +435,21 @@ describe('Popover dropdown sizing (#44)', () => {
         focusRevealProps: { popoverProps: { position: 'top' } },
       },
     ];
-    const { container } = render(
+    render(
       <OnboardingTour
         tour={steps}
         started
-        focusRevealProps={{ popoverProps: { styles: { dropdown: { maxWidth: 500 } } } }}
+        focusRevealProps={{
+          popoverProps: { styles: { dropdown: { backgroundColor: 'rgb(1, 2, 3)' } } },
+        }}
       >
         <Button data-onboarding-tour-id="welcome">Target</Button>
       </OnboardingTour>
     );
-    expect(container).toBeTruthy();
-    expect(screen.getByText('Target')).toBeInTheDocument();
+    const dropdown = await findDropdown();
+    expect(dropdown).toHaveStyle({ backgroundColor: 'rgb(1, 2, 3)' });
+    // The default cap class is still applied alongside the consumer's styles override.
+    expect(dropdown.classList.contains('dropdown')).toBe(true);
   });
 });
 

--- a/package/src/OnboardingTour.tsx
+++ b/package/src/OnboardingTour.tsx
@@ -197,11 +197,20 @@ export const OnboardingTour = factory<OnboardingTourFactory>((_props) => {
         const childProps = child.props as Record<string, unknown>;
         const tourId = childProps['data-onboarding-tour-id'] as string | undefined;
         if (tourId) {
+          // Deep-merge tour-level and step-level focusRevealProps so a step that defines its own
+          // `popoverProps`/`overlayProps` doesn't drop the tour-level ones — a plain spread would
+          // replace the whole nested object. `currentStepFocusRevealProps` is the resolved step value.
           const mergedFocusRevealProps = {
             ...focusRevealProps,
-            ...(typeof onboardingTour.currentStep?.focusRevealProps === 'function'
-              ? onboardingTour.currentStep.focusRevealProps(onboardingTour)
-              : onboardingTour.currentStep?.focusRevealProps),
+            ...currentStepFocusRevealProps,
+            popoverProps: {
+              ...focusRevealProps?.popoverProps,
+              ...currentStepFocusRevealProps?.popoverProps,
+            },
+            overlayProps: {
+              ...focusRevealProps?.overlayProps,
+              ...currentStepFocusRevealProps?.overlayProps,
+            },
           };
 
           return (

--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.module.css
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.module.css
@@ -141,8 +141,9 @@
  * Default width ceiling for the tour popover dropdown. `width: 'max-content'` alone has
  * `max-width: none`, so wide/non-wrapping content overflows the viewport. Applied as a class
  * (not inline `styles`) so it survives consumer `popoverProps.styles.dropdown` overrides of
- * other properties (e.g. padding). Override the cap with `styles.dropdown.maxWidth` (inline
- * wins over the class) or with `popoverProps.width`.
+ * other properties (e.g. padding). `popoverProps.width` sizes the dropdown up to this cap; to
+ * make it wider than 400px, raise or remove the cap with `styles.dropdown.maxWidth` (inline wins
+ * over the class; `'none'` removes it).
  */
 .dropdown {
   max-width: 400px;

--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.module.css
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.module.css
@@ -137,6 +137,17 @@
   inset: 0;
 }
 
+/*
+ * Default width ceiling for the tour popover dropdown. `width: 'max-content'` alone has
+ * `max-width: none`, so wide/non-wrapping content overflows the viewport. Applied as a class
+ * (not inline `styles`) so it survives consumer `popoverProps.styles.dropdown` overrides of
+ * other properties (e.g. padding). Override the cap with `styles.dropdown.maxWidth` (inline
+ * wins over the class) or with `popoverProps.width`.
+ */
+.dropdown {
+  max-width: 400px;
+}
+
 .focused {
   &[data-onboarding-tour-focus-reveal-focused] {
     &[data-onboarding-tour-focus-reveal-mode='pulse'] {

--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
@@ -195,6 +195,12 @@ export const defaultProps: Partial<OnboardingTourFocusRevealProps> = {
     radius: 'md',
     shadow: 'xl',
     middlewares: { shift: { padding: 20 }, flip: true },
+    // Cap the dropdown width by default. `width: 'max-content'` alone has `max-width: none`,
+    // so wide/non-wrapping content (images, code, fixed layouts) overflows past the viewport
+    // and — combined with the tour's `overflow-x: hidden` — makes `position` look broken.
+    // `styles.dropdown` is applied after the internal `width`, so this max-width wins.
+    // Override per tour/step via `popoverProps.styles.dropdown.maxWidth` or `popoverProps.width`.
+    styles: { dropdown: { maxWidth: 400 } },
   },
 };
 

--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
@@ -195,6 +195,11 @@ export const defaultProps: Partial<OnboardingTourFocusRevealProps> = {
     radius: 'md',
     shadow: 'xl',
     middlewares: { shift: { padding: 20 }, flip: true },
+    // Keep flipping/shifting the popover while a step stays visible, regardless of the installed
+    // Mantine version. Mantine 9.3 flipped Popover's `preventPositionChangeWhenVisible` default to
+    // `true` (pins the side on open); the tour scrolls targets around, so it relies on live
+    // re-positioning. Consumers can opt back in with `popoverProps.preventPositionChangeWhenVisible`.
+    preventPositionChangeWhenVisible: false,
   },
 };
 

--- a/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
+++ b/package/src/OnboardingTourFocusReveal/OnboardingTourFocusReveal.tsx
@@ -195,12 +195,6 @@ export const defaultProps: Partial<OnboardingTourFocusRevealProps> = {
     radius: 'md',
     shadow: 'xl',
     middlewares: { shift: { padding: 20 }, flip: true },
-    // Cap the dropdown width by default. `width: 'max-content'` alone has `max-width: none`,
-    // so wide/non-wrapping content (images, code, fixed layouts) overflows past the viewport
-    // and — combined with the tour's `overflow-x: hidden` — makes `position` look broken.
-    // `styles.dropdown` is applied after the internal `width`, so this max-width wins.
-    // Override per tour/step via `popoverProps.styles.dropdown.maxWidth` or `popoverProps.width`.
-    styles: { dropdown: { maxWidth: 400 } },
   },
 };
 
@@ -380,7 +374,9 @@ export function OnboardingTourFocusReveal(_props: OnboardingTourFocusRevealProps
     return (
       <Popover opened={realFocused && !!popoverContent} {...finalPopoverProps}>
         <Popover.Target>{cloneElement(child, newProps)}</Popover.Target>
-        <Popover.Dropdown>{popoverContent}</Popover.Dropdown>
+        {/* Default width cap via class so it survives consumer `styles.dropdown` overrides;
+            Mantine merges this className with any `popoverProps.classNames.dropdown`. */}
+        <Popover.Dropdown className={classes.dropdown}>{popoverContent}</Popover.Dropdown>
       </Popover>
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes the tour popover's width and positioning defaults. Bundles two related issues that both live in the `OnboardingTourFocusReveal` popover defaults.

## #44 — Popover has no width ceiling

The dropdown was rendered with `width: 'max-content'` / `max-width: none`, so wide or non-wrapping content (images, `<Code>`, fixed-width layouts) overflowed the viewport. Combined with the tour's `overflow-x: hidden`, this also made **`position` look broken** — the dropdown got clipped off the left edge no matter which `position` value was passed.

- **Default `max-width: 400px`** on the dropdown, shipped as a `.dropdown` **CSS class** applied on `Popover.Dropdown` via `className` (Mantine merges it with any consumer `classNames.dropdown`). Applying it as a class — rather than inline `styles` — means it survives any consumer `popoverProps.styles.dropdown` override of other properties (e.g. `padding`), and stays overridable with `styles.dropdown.maxWidth` (inline wins) or `width`. _(This addresses the CodeRabbit/Copilot review: the earlier inline-`styles` default was fragile.)_
- **Deep-merge `popoverProps`/`overlayProps`** across tour-level and step-level `focusRevealProps` (one level), so a step that sets its own `popoverProps` no longer drops tour-level popover config.
- **Docs**: new "Popover width" subsection + a runnable "Reveal the Bottom Card" demo.

## #41 — Pin/keep positioning under Mantine 9.3

Mantine 9.3 flipped `Popover`'s `preventPositionChangeWhenVisible` default to `true` (the popover pins its side on open and stops flip/shift while visible). The tour scrolls targets around and relies on live re-positioning, so it now sets `preventPositionChangeWhenVisible: false` in its default `popoverProps` — identical behavior on Mantine 9.2 and 9.3+. Consumers can opt back in per tour/step. Documented in "Scroll Behavior".

## Verification

- `yarn build` + `yarn docgen` + `yarn docs:build` pass; `yarn test` — **43/43** green (new #44 tests mount the popover via an IntersectionObserver mock and assert the cap class + deep-merge; #41 locks the positioning default).
- #44 verified live in Storybook: rendered dropdown `max-width: 400px`, used `width: 400px`, positioned on-screen with text wrapped — instead of a ~1392px dropdown clipped off the left edge.

## Notes

- The pervasive `maw={400}` on `<OnboardingTour>` in the demos is now redundant (harmless) — left as-is to keep the diff focused.

Fixes #44
Fixes #41


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Focus Reveal demo for controlling popover dropdown width.

* **Bug Fixes**
  * Improved Focus Reveal prop merging to preserve tour-level popover/overlay settings while applying step-level overrides reliably.

* **Documentation**
  * Expanded Focus Reveal docs on popover sizing and movement behavior, including default 400px dropdown max-width, what the sizing targets, and override precedence.
  * Updated examples for responsive and scroll behavior, including how to pin positioning when visible.

* **Tests**
  * Added coverage for default dropdown sizing, merge precedence, and positioning defaults.
  * Improved test reliability with IntersectionObserver and `scrollIntoView` mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->